### PR TITLE
update to new packages and bump version (main)

### DIFF
--- a/scripts/bootstrap_env.sh
+++ b/scripts/bootstrap_env.sh
@@ -2,25 +2,25 @@
 
 ARCH=`uname -m`
 
-ORG="eosnetworkfoundation"
-NODE_VERSION="3.1.0-rc2"
-CDT_VERSION="3.0.0-rc1"
+ORG="AntelopeIO"
+NODE_VERSION="3.1.0-rc4"
+CDT_VERSION="3.0.0-rc2"
 
 
-CONTAINER_PACKAGE=eosnetworkfoundation/experimental-binaries
+CONTAINER_PACKAGE=AntelopeIO/experimental-binaries
 GH_ANON_BEARER=$(curl -s "https://ghcr.io/token?service=registry.docker.io&scope=repository:${CONTAINER_PACKAGE}:pull" | jq -r .token)
 curl -s -L -H "Authorization: Bearer ${GH_ANON_BEARER}" https://ghcr.io/v2/${CONTAINER_PACKAGE}/blobs/$(curl -s -L -H "Authorization: Bearer ${GH_ANON_BEARER}" https://ghcr.io/v2/${CONTAINER_PACKAGE}/manifests/v3.1.0-rc2 | jq -r .layers[0].digest) | tar zx
 
 if [ "${ARCH}" = "x86_64" ]; then
-   wget https://github.com/${ORG}/mandel/releases/download/v${NODE_VERSION}/mandel-${NODE_VERSION}-ubuntu20.04-x86_64.deb
-   apt install ./mandel-${NODE_VERSION}-ubuntu20.04-x86_64.deb
-   apt install ./mandel-dev-${NODE_VERSION}-ubuntu20.04-x86_64.deb
-   wget https://github.com/${ORG}/mandel.cdt/releases/download/v${CDT_VERSION}/cdt_${CDT_VERSION}_amd64.deb
+   wget https://github.com/${ORG}/leap/releases/download/v${NODE_VERSION}/leap-${NODE_VERSION}-ubuntu20.04-x86_64.deb
+   apt install ./leap-${NODE_VERSION}-ubuntu20.04-x86_64.deb
+   apt install ./leap-dev-${NODE_VERSION}-ubuntu20.04-x86_64.deb
+   wget https://github.com/${ORG}/cdt/releases/download/v${CDT_VERSION}/cdt_${CDT_VERSION}_amd64.deb
    apt install ./cdt_${CDT_VERSION}_amd64.deb
 else
-   apt install ./mandel-${NODE_VERSION}-ubuntu20.04-aarch64.deb
-   apt install ./mandel-dev-${NODE_VERSION}-ubuntu20.04-aarch64.deb
-   wget https://github.com/${ORG}/mandel.cdt/releases/download/v${CDT_VERSION}/cdt_${CDT_VERSION}_arm64.deb
+   apt install ./leap-${NODE_VERSION}-ubuntu20.04-aarch64.deb
+   apt install ./leap-dev-${NODE_VERSION}-ubuntu20.04-aarch64.deb
+   wget https://github.com/${ORG}/cdt/releases/download/v${CDT_VERSION}/cdt_${CDT_VERSION}_arm64.deb
    apt install ./cdt_${CDT_VERSION}_arm64.deb
 fi
 

--- a/scripts/bootstrap_env.sh
+++ b/scripts/bootstrap_env.sh
@@ -9,7 +9,7 @@ CDT_VERSION="3.0.0-rc2"
 
 CONTAINER_PACKAGE=AntelopeIO/experimental-binaries
 GH_ANON_BEARER=$(curl -s "https://ghcr.io/token?service=registry.docker.io&scope=repository:${CONTAINER_PACKAGE}:pull" | jq -r .token)
-curl -s -L -H "Authorization: Bearer ${GH_ANON_BEARER}" https://ghcr.io/v2/${CONTAINER_PACKAGE}/blobs/$(curl -s -L -H "Authorization: Bearer ${GH_ANON_BEARER}" https://ghcr.io/v2/${CONTAINER_PACKAGE}/manifests/v3.1.0-rc2 | jq -r .layers[0].digest) | tar zx
+curl -s -L -H "Authorization: Bearer ${GH_ANON_BEARER}" https://ghcr.io/v2/${CONTAINER_PACKAGE}/blobs/$(curl -s -L -H "Authorization: Bearer ${GH_ANON_BEARER}" https://ghcr.io/v2/${CONTAINER_PACKAGE}/manifests/v${NODE_VERSION} | jq -r .layers[0].digest) | tar -xz
 
 if [ "${ARCH}" = "x86_64" ]; then
    wget https://github.com/${ORG}/leap/releases/download/v${NODE_VERSION}/leap-${NODE_VERSION}-ubuntu20.04-x86_64.deb

--- a/src/dune/dune.py
+++ b/src/dune/dune.py
@@ -11,7 +11,7 @@ def version_minor():
 def version_patch():
    return 0
 def version_suffix():
-   return "rc1"
+   return "rc2"
 def version_full():
    return "v"+str(version_major())+"."+str(version_minor())+"."+str(version_patch())+"."+version_suffix()
 class dune_error(Exception):


### PR DESCRIPTION
Merging PR #7 into main.

Update DUNE to point to the new AntelopeIO packages for CDT and Leap.

In addition this PR also bumps DUNE's version to v1.0.0-rc2.

This PR is a draft as there seems to be issues with Leap's dev packages. When that is resolved I will un-draft the PR and merge.
