### PR TITLE
added message for unsupported or wrong dune command

### DIFF
--- a/src/dune/__main__.py
+++ b/src/dune/__main__.py
@@ -131,6 +131,9 @@ if __name__ == '__main__':
 
          elif args.version:
             print ("DUNE "+version_full())
+            
+         else:
+            print("Unsupported or wrong command")
 
       except KeyboardInterrupt:
          pass


### PR DESCRIPTION
Sometime I mistakenly type docker command options after dune command and realise it later because dune is shutting its mouth.
A trivial improvement for careless devs. :)