### PR TITLE
fix build errors

### DIFF
--- a/Dockerfile.unix
+++ b/Dockerfile.unix
@@ -35,10 +35,10 @@ RUN if [ ${USER_ID:-0} -ne 0 ] && [ ${GROUP_ID:-0} -ne 0 ]; then \
           /home/www-data \
           /app \
    ;fi
-USER www-data
 
-RUN mkdir /home/www-data/nodes
+RUN mkdir -p /home/www-data/nodes
 RUN cp /app/config.ini /home/www-data/config.ini
+USER www-data
 
 # thanks to github.com/phusion
 # this should solve reaping issues of stopped nodes


### PR DESCRIPTION
**Description:**

Unix build fails with the following errors:

```
Step 22/28 : RUN mkdir -p /home/www-data/nodes
 ---> Running in 3f0b301575a6
mkdir: cannot create directory '/home/www-data': Permission denied
The command '/bin/sh -c mkdir -p /home/www-data/nodes' returned a non-zero code: 1
```

```
Step 22/28 : RUN mkdir /home/www-data/nodes
 ---> Running in 0bc2122e9199
mkdir: cannot create directory '/home/www-data/nodes': No such file or directory
The command '/bin/sh -c mkdir /home/www-data/nodes' returned a non-zero code: 1
```

**Expected Behavior:**

Should build without errors.

**Steps to reproduce**

```
sudo docker build -t natpdev/dune-unix -f Dockerfile.unix .
```