### PR TITLE
[1.0] fix arguments incorrectly split if arguments contain spaces

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 SDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-python3 $SDIR/src/dune $@
+python3 $SDIR/src/dune "$@"


### PR DESCRIPTION
Resolve https://github.com/AntelopeIO/DUNE/issues/21

Previously if spaces were in an argument, that argument would be split by the spaces, as we saw in the following reported error:

```
dune -- cleos push action hello create '{"issuer":"hello", "maximum_supply":"1000000000.0000 SYS"}' -p hello@active
**Return result: ** The following arguments were not expected: SYS"} "maximum_supply":"1000000000.0000
``` 

The solution is to wrap around the arguments string with double quotes in the bash script.