### PR TITLE
fix bootstrap error

### DIFF
--- a/src/dune/dune.py
+++ b/src/dune/dune.py
@@ -403,7 +403,7 @@ class dune:
       elif code_name == "FORWARD_SETCODE":
          self.send_action('activate', 'eosio', '["2652f5f96006294109b3dd0bbde63693f55324af452b799ee137a81a905eed25"]', 'eosio@active')
       elif code_name == "ONLY_BILL_FIRST_AUTHORIZER":
-         self.send_action('activate', 'eosio', '["8ba52fe7a3956c5cd3a656a3174b931d3bb2abb45578befc59f283ecd816a405"', 'eosio@active')
+         self.send_action('activate', 'eosio', '["8ba52fe7a3956c5cd3a656a3174b931d3bb2abb45578befc59f283ecd816a405"]', 'eosio@active')
       elif code_name == "RESTRICT_ACTION_TO_SELF":
          self.send_action('activate', 'eosio', '["ad9e3d8f650687709fd68f4b90b41f7d825a365b02c23a636cef88ac2ac00c43"]', 'eosio@active')
       elif code_name == "DISALLOW_EMPTY_PRODUCER_SCHEDULE":


### PR DESCRIPTION
#### Description

One of the protocol feature activations fails with the following error
```
Error 3100010: JSON parse exception
Error Details:
Fail to parse JSON from string: ["8ba52fe7a3956c5cd3a656a3174b931d3bb2abb45578befc59f283ecd816a405"
unexpected end of file
Attempting to parse array ["8ba52fe7a3956c5cd3a656a3174b931d3bb2abb45578befc59f283ecd816a405"]
{"str":"[\"8ba52fe7a3956c5cd3a656a3174b931d3bb2abb45578befc59f283ecd816a405\""}
Stack Trace:
main.cpp:519 json_from_file_or_string
json_relaxed.hpp:744 variant_from_stream
json_relaxed.hpp:651 arrayFromStream
json.cpp:459 from_string
```

#### Expected Behavior:

Should activate the protocol features without errors.

#### Steps to reproduce
```bash
# Start a node
dune --start <node_name>
# Do a system bootstrap
dune --bootstrap-system
```
