### PR TITLE
Fix cause of issues with shared files

### DIFF
--- a/Dockerfile.unix
+++ b/Dockerfile.unix
@@ -35,9 +35,9 @@ RUN if [ ${USER_ID:-0} -ne 0 ] && [ ${GROUP_ID:-0} -ne 0 ]; then \
           /home/www-data \
           /app \
    ;fi
-USER www-data
 
-RUN mkdir /home/www-data/nodes
+# USER www-data
+RUN mkdir -p /home/www-data/nodes
 RUN cp /app/config.ini /home/www-data/config.ini
 
 # thanks to github.com/phusion

--- a/Dockerfile.unix
+++ b/Dockerfile.unix
@@ -36,7 +36,6 @@ RUN if [ ${USER_ID:-0} -ne 0 ] && [ ${GROUP_ID:-0} -ne 0 ]; then \
           /app \
    ;fi
 
-# USER www-data
 RUN mkdir -p /home/www-data/nodes
 RUN cp /app/config.ini /home/www-data/config.ini
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,9 +2,9 @@
 
 SDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-GROUP_ID=$(id -g ${USER})
 # for mac users
 if [[ $(uname) == "Darwin" ]]; then
   GROUP_ID=200
 fi
-docker build --no-cache --build-arg USER_ID=$(id -u ${USER}) --build-arg GROUP_ID=${GROUP_ID} -f Dockerfile.unix -t dune $SDIR
+
+docker build --no-cache --build-arg USER_ID=0 --build-arg GROUP_ID=0 -f Dockerfile.unix -t dune $SDIR


### PR DESCRIPTION
Synchronization of access rights to shared files between of the host and the container was based on a small hack where we create users with the same UID and GID on the host and in the container. Linux doesn't care of user names but only of id numbers so it considers users with the same ids as the same user. This mechanism worked well until namespaces mapping and rootless start were added to Docker. Since that moment these mechanisms interfere with each other and it causes the bugs.

Docker Desktop works with userns-remap turned on only. I found that Docker Desktop doesn't use dockerd daemon at all. I started Docker Desktop and stopped the daemon but DUNE commands still work well. It seems Docker Desktop has builtin daemon which works in parallel with the dockerd daemon. It is very easy to confuse which system you are currently working with. It cause issues and misunderstandings.

This fix removes the hack with creation in the container of a user with the same UID and GID as the host user. It allows Docker with turned on userns-remap correctly map UID and GID of a user from the container to a current host user. So all shared files get the UID and GID of a current host user.