### PR TITLE
Fix start option

### DIFF
--- a/src/dune/__main__.py
+++ b/src/dune/__main__.py
@@ -1,3 +1,5 @@
+import os   # path
+
 from args import arg_parser
 from args import parse_optional
 from dune import dune
@@ -21,12 +23,28 @@ if __name__ == '__main__':
         try:
             if args.start is not None:
                 n: object
-                if len(args.start) == 1:
+                if args.config is None:
                     n = node(args.start[0])
+                elif len(args.config) == 1:
+                    cfg_temp = args.config[0]
+                    if not os.path.exists(cfg_temp):
+                        parser.exit_with_help_message("--config: config.ini unknown path\n",
+                                                       "bad value: ", cfg_temp)
+                    if os.path.isdir(cfg_temp):
+                        cfg_temp = os.path.join(cfg_temp, "config.ini")
+                    if os.path.split(cfg_temp)[1] != "config.ini":
+                        parser.exit_with_help_message("--config: config must either be a a config.ini file or a path containg one\n"
+                                                      "bad value: ", cfg_temp)
+                    if not os.path.exists(cfg_temp):
+                        parser.exit_with_help_message("--config: config.ini file must exist\n"
+                                                      "bad value: ", cfg_temp)
+                    n = node(args.start[0], dune_sys.docker.abs_host_path(cfg_temp))
                 else:
-                    n = node(args.start[0],
-                             dune_sys.docker.abs_host_path(args.start[1]))
+                    parser.exit_with_help_message("--start / --config error")
                 dune_sys.start_node(n)
+
+            elif args.config is not None:
+                parser.exit_with_help_message("--config without --start")
 
             elif args.remove is not None:
                 dune_sys.remove_node(node(args.remove))

--- a/src/dune/__main__.py
+++ b/src/dune/__main__.py
@@ -33,7 +33,8 @@ if __name__ == '__main__':
                     if os.path.isdir(cfg_temp):
                         cfg_temp = os.path.join(cfg_temp, "config.ini")
                     if os.path.split(cfg_temp)[1] != "config.ini":
-                        parser.exit_with_help_message("--config: config must either be a a config.ini file or a path containg one\n"
+                        parser.exit_with_help_message("--config: config must either be a config.ini"
+                                                      "file or a path containg one\n"
                                                       "bad value: ", cfg_temp)
                     if not os.path.exists(cfg_temp):
                         parser.exit_with_help_message("--config: config.ini file must exist\n"

--- a/src/dune/args.py
+++ b/src/dune/args.py
@@ -43,9 +43,11 @@ class arg_parser:
     def __init__(self):
         self._parser = argparse.ArgumentParser(
             description='DUNE: Docker Utilities for Node Execution')
-        self._parser.add_argument('--start', nargs='+', metavar=["NODE", "CONFIG-DIR (Optional)"],
-                                  help='start a new node with a given name and an optional '
-                                       'config.ini')
+        self._parser.add_argument('-s','--start', nargs=1, metavar=("NODE"),
+                                  help='start a new node with a given name' )
+        self._parser.add_argument('-c','--config', nargs=1, metavar=("CONFIG_DIR"),
+                                  help='optionally used with --start, a path containing'
+                                  ' the config.ini file to use' )
         self._parser.add_argument('--stop', metavar="NODE", help='stop a node with a given name')
         self._parser.add_argument('--remove', metavar="NODE",
                                   help='a node with a given name, will stop the node if running')
@@ -150,3 +152,8 @@ class arg_parser:
 
     def parse(self):
         return self._parser.parse_args()
+
+    def exit_with_help_message(self, *args, return_value=1):
+        self._parser.print_help(sys.stderr)
+        print("\nError: ", *args, file=sys.stderr)
+        sys.exit(return_value)


### PR DESCRIPTION
Fixes #54 

Modify CLI arguments:
    `-s, --start`:  NO longer takes a config, it becomes a separate argument.
    `-c, --config`: argument added to allow for config.ini argument.

Add `exit_with_help_message()` function to args class to allow main to behave a bit more unix-y. This function is used to alert the user when a bad value is sent to `--config`.
