### PR TITLE
Correct column widths in `--list` node display to be aesthetically pleasing.

### DIFF
--- a/src/dune/dune.py
+++ b/src/dune/dune.py
@@ -233,13 +233,9 @@ class dune:
         if simple:
             print("Node|Active|Running|HTTP|P2P|SHiP")
         else:
-            while len(node_name) < name_width:
-                node_name += " "
-            dash = ""
-            while len(dash) < name_width:
-                dash += "-"
-            print(node_name + "| Active? | Running? | HTTP           | P2P          | SHiP\n"
-                  + dash +    "---------------------------------------------------------------------")
+            header = '| Active? | Running? | HTTP           | P2P          | SHiP          '
+            print(f'{node_name : <{name_width}}{header}')
+            print(f'{"":{"-"}<{name_width + len(header)}}')
 
         for state in states:
             print( state.string(sep=sep, simple=simple, name_width=name_width) )

--- a/src/dune/dune.py
+++ b/src/dune/dune.py
@@ -221,15 +221,28 @@ class dune:
     # pylint: disable=too-many-branches
     def list_nodes(self, simple=False, sep='|'):
 
+        buffer = 3
+        node_name = "Node Name"
+
+        states=self.state_list()
+        name_width = len(node_name) + buffer;
+        if not simple:
+            for state in states:
+                name_width = max( len(state.name) + buffer, name_width)
+
         if simple:
             print("Node|Active|Running|HTTP|P2P|SHiP")
         else:
-            print("Node Name\t\t | Active? | Running? | HTTP           | P2P          | SHiP\n"
-                  "----------------------------------------------------------------------------------------------")
+            while len(node_name) < name_width:
+                node_name += " "
+            dash = ""
+            while len(dash) < name_width:
+                dash += "-"
+            print(node_name + "| Active? | Running? | HTTP           | P2P          | SHiP\n"
+                  + dash +    "---------------------------------------------------------------------")
 
-        states=self.state_list()
         for state in states:
-            print( state.string(sep=sep, simple=simple) )
+            print( state.string(sep=sep, simple=simple, name_width=name_width) )
 
     # pylint: disable=too-many-locals,too-many-statements
     def export_node(self, nod, path):

--- a/src/dune/dune.py
+++ b/src/dune/dune.py
@@ -225,7 +225,7 @@ class dune:
         node_name = "Node Name"
 
         states=self.state_list()
-        name_width = len(node_name) + buffer;
+        name_width = len(node_name) + buffer
         if not simple:
             for state in states:
                 name_width = max( len(state.name) + buffer, name_width)

--- a/src/dune/node_state.py
+++ b/src/dune/node_state.py
@@ -45,4 +45,5 @@ class node_state:
         buffer = ""
         while (len(self.name) + len(buffer)) < name_width:
             buffer += " "
-        return f"{self.name}{buffer}{sep}    {active_str}    {sep}    {running_str}     {sep} {self.http} {sep} {self.p2p} {sep} {self.ship}"
+        return \
+            f"{self.name}{buffer}{sep}    {active_str}    {sep}    {running_str}     {sep} {self.http} {sep} {self.p2p} {sep} {self.ship}"

--- a/src/dune/node_state.py
+++ b/src/dune/node_state.py
@@ -42,8 +42,5 @@ class node_state:
             running_str='Y'
         if simple:
             return f"{self.name}{sep}{active_str}{sep}{running_str}{sep}{self.http}{sep}{self.p2p}{sep}{self.ship}"
-        buffer = ""
-        while (len(self.name) + len(buffer)) < name_width:
-            buffer += " "
-        return \
-            f"{self.name}{buffer}{sep}    {active_str}    {sep}    {running_str}     {sep} {self.http} {sep} {self.p2p} {sep} {self.ship}"
+        return f"{self.name}{' ' * (name_width - len(self.name))}" + \
+            f"{sep}    {active_str}    {sep}    {running_str}     {sep} {self.http} {sep} {self.p2p} {sep} {self.ship}"

--- a/src/dune/node_state.py
+++ b/src/dune/node_state.py
@@ -33,7 +33,7 @@ class node_state:
         return f"{self.name}, {active_str}, {running_str}, {self.http}, {self.p2p}, {self.ship}"
 
 
-    def string(self, file=sys.stdout, sep=',', simple=True):
+    def string(self, file=sys.stdout, sep=',', simple=True, name_width=0):
         active_str='N'
         if self.is_active:
             active_str='Y'
@@ -42,4 +42,7 @@ class node_state:
             running_str='Y'
         if simple:
             return f"{self.name}{sep}{active_str}{sep}{running_str}{sep}{self.http}{sep}{self.p2p}{sep}{self.ship}"
-        return f"{self.name}\t\t {sep}    {active_str}\t   {sep}    {running_str}     {sep} {self.http} {sep} {self.p2p} {sep} {self.ship}"
+        buffer = ""
+        while (len(self.name) + len(buffer)) < name_width:
+            buffer += " "
+        return f"{self.name}{buffer}{sep}    {active_str}    {sep}    {running_str}     {sep} {self.http} {sep} {self.p2p} {sep} {self.ship}"


### PR DESCRIPTION
Correct column widths in `--list` node display to be aesthetically pleasing when node names vary in size.

This fixes #76 

Broken sample:
```
Node Name		 | Active? | Running? | HTTP           | P2P          | SHiP
----------------------------------------------------------------------------------------------
my_node		 |    N	   |    N     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080
some_node		 |    N	   |    N     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080
some_other_node		 |    N	   |    N     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080
this_is_the_name_that_never_ends_it_goes_on_and_on		 |    Y	   |    Y     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080
```

Corrected samples:
```
Node Name                                            | Active? | Running? | HTTP           | P2P          | SHiP
--------------------------------------------------------------------------------------------------------------------------
my_node                                              |    N    |    N     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080
some_node                                            |    N    |    N     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080
some_other_node                                      |    N    |    N     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080
this_is_the_name_that_never_ends_it_goes_on_and_on   |    Y    |    Y     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080


Node Name         | Active? | Running? | HTTP           | P2P          | SHiP
---------------------------------------------------------------------------------------
my_node           |    N    |    N     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080
some_node         |    N    |    N     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080
some_other_node   |    N    |    N     | 127.0.0.1:8888 | 0.0.0.0:9876 | 127.0.0.1:8080
```

