### PR TITLE
Easy install of DUNE on Windows (publishing DUNE to Chocolatey repository)

### DIFF
--- a/packaging/antelopeio-dune/antelopeio-dune.nuspec
+++ b/packaging/antelopeio-dune/antelopeio-dune.nuspec
@@ -20,6 +20,10 @@
 Docker Utilities for Node Execution (DUNE) is a tool to abstract over Leap programs, CDT and other services/tools related to Antelope blockchains.
     
     </description>
+    <dependencies>
+      <dependency id="python"/>
+      <dependency id="docker-desktop"/>
+    </dependencies>
   </metadata>
   <files>
     <!-- this section controls what actually gets packaged into the Chocolatey package -->

--- a/packaging/antelopeio-dune/antelopeio-dune.nuspec
+++ b/packaging/antelopeio-dune/antelopeio-dune.nuspec
@@ -4,7 +4,6 @@
   <metadata>
     <id>antelopeio-dune</id>
     <version>1.0.0</version>
-    <packageSourceUrl>https://github.com/AntelopeIO/DUNE/packaging/antelopeio-dune.nuspec</packageSourceUrl>
     <owners>EOS Network Foundation</owners>
     <title>AntelopeIO DUNE</title>
     <authors>EOS Network Foundation</authors>
@@ -16,7 +15,7 @@
     <projectSourceUrl>https://github.com/AntelopeIO/DUNE</projectSourceUrl>
     <bugTrackerUrl>https://github.com/AntelopeIO/DUNE/issues</bugTrackerUrl>
     <summary>antelopeio-dune</summary>
-    <description>### antelopeio-dune package
+    <description>### antelopeio-dune eos cleos nodeos leap cdt antelope antelopeio
 Docker Utilities for Node Execution (DUNE) is a tool to abstract over Leap programs, CDT and other services/tools related to Antelope blockchains.
     
     </description>


### PR DESCRIPTION
I have pushed DUNE to Chocolatey repository:
[](https://community.chocolatey.org/packages/antelopeio-dune/1.0.0)

To install DUNE on Windows from scratch two steps are needed:
1. [Install Chocolatey](https://chocolatey.org/install)
2. In PowerShell run as administrator following command:
`choco install antelopeio-dune --version=1.0.0`

NOTE: After DUNE package is reviewed by Chocolatey's moderator it will be possible to skip "version" in above command.