### PR TITLE
Adding Leap and CDT version selector

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint pytest
+        pip install pylint pytest requests
     - name: Analysing the code with pylint
       run: |
         pylint -j4 $(git ls-files '*.py')

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest requests
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/README.md
+++ b/README.md
@@ -336,12 +336,12 @@ This will list the available protocol feature code names.
 ---
 
 **--leap** 
-Sets specific version of leap
+Sets specific version of leap. If no version is provided then a list of available Leap versions will be displayed.
 
 ---
 
 **--cdt** 
-Sets specific version of CDT (Contract Development Toolkit)
+Sets specific version of CDT (Contract Development Toolkit). If no version is provided then a list of available CDT versions will be displayed.
 
 ---
 **--version-all** 

--- a/src/dune/__main__.py
+++ b/src/dune/__main__.py
@@ -4,6 +4,7 @@ import importlib.util
 
 from args import arg_parser
 from args import parse_optional
+import version_selector
 from dune import dune
 from dune import dune_error
 from dune import dune_node_not_found
@@ -239,9 +240,13 @@ if __name__ == '__main__':
                 dune_sys.docker.upgrade()
 
             elif args.leap:
+                if args.leap == '-1':
+                    args.leap = version_selector.get_version("Leap")
                 dune_sys.execute_cmd(['sh', 'bootstrap_leap.sh', args.leap])
 
             elif args.cdt:
+                if args.cdt == '-1':
+                    args.cdt = version_selector.get_version("CDT")
                 dune_sys.execute_cmd(['sh', 'bootstrap_cdt.sh', args.cdt])
 
             elif args.version_all:

--- a/src/dune/args.py
+++ b/src/dune/args.py
@@ -126,7 +126,8 @@ class arg_parser:
                                        'needed for core contract and deploys core, token, '
                                        'and multisig contracts')
         self._parser.add_argument('--send-action', nargs=4, action=fix_action_data,
-                                  metavar=["ACCOUNT", "ACTION", "DATA", "PERMISSION"],
+                                  metavar=["ACCOUNT", "ACTION",
+                                           "DATA", "PERMISSION"],
                                   help='send action to account with data given and permission')
         self._parser.add_argument('--get-table', nargs=3, metavar=["ACCOUNT", "SCOPE", "TABLE"],
                                   help='get the data from the given table')
@@ -145,9 +146,11 @@ class arg_parser:
         self._parser.add_argument(
             '--upgrade', action='store_true', help='upgrades DUNE image to the latest version')
         self._parser.add_argument(
-            '--leap', metavar="LEAP_VERSION", help='sets the version of leap')
-        self._parser.add_argument('--cdt', metavar="CDT_VERSION", help='sets the version of CDT (Contract '
-                                  'Development Toolkit)')
+            '--leap', nargs='?', const='-1', metavar="LEAP_VERSION", help='sets the version of leap. '
+            'If no version is provided then available leap versions are displayed.')
+        self._parser.add_argument(
+            '--cdt', nargs='?', const='-1', metavar="CDT_VERSION", help='sets the version of CDT (Contract '
+            'Development Toolkit). If no version is provided then available CDT versions are displayed')
         # used to store arguments to individual programs, starting with --
         self._parser.add_argument('remainder',
                                   nargs=argparse.REMAINDER)

--- a/src/dune/version_selector.py
+++ b/src/dune/version_selector.py
@@ -1,0 +1,58 @@
+import json
+import sys
+import requests
+
+
+def available_versions_from_url(url):
+    versions = []
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28"
+    }
+
+    response = requests.get(url, headers=headers, timeout=30)
+    data = json.loads(response.text)
+
+    for release in data:
+        versions.append(release["tag_name"])
+
+    return versions
+
+
+def available_versions(project):
+    url = ""
+    project_lowercase = project.lower()
+
+    if project_lowercase == "leap":
+        url = "https://api.github.com/repos/antelopeio/leap/releases"
+    elif project_lowercase == "cdt":
+        url = "https://api.github.com/repos/antelopeio/cdt/releases"
+    else:
+        print("Unknown project " + project)
+        sys.exit()
+
+    return available_versions_from_url(url)
+
+
+def get_version(project):
+    versions = available_versions(project)
+    print("Available " + project + " versions:")
+    for index, version in enumerate(versions):
+        print(str(index + 1) + ") " + version)
+
+    user_choice = input(
+        "Enter which version you want to choose [1," + str(len(versions)) + "]? ")
+    try:
+        user_choice = int(user_choice)
+    # pylint: disable=bare-except
+    except:
+        print("Improper version choosen.")
+        sys.exit()
+
+    if user_choice < 1 or user_choice > len(versions):
+        print("Improper version choosen.")
+        sys.exit()
+
+    chosen_element = versions[user_choice - 1]
+
+    return chosen_element[1:]

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -41,7 +41,6 @@ def test_help():
         [
             b'usage: dune',
             b'DUNE: Docker Utilities for Node Execution',
-            b'optional arguments:',
             b'-h, --help',
             b'--monitor',
             b'--start',

--- a/tests/test_version_selector.py
+++ b/tests/test_version_selector.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+"""Test CDT/Leap version selector
+"""
+import sys
+from unittest.mock import patch
+from unittest import TestCase
+from os.path import dirname, realpath
+
+sys.path.insert(1, sys.path.append(dirname(realpath(__file__)) + "/../src/dune"))
+# pylint: disable=wrong-import-position
+import version_selector
+
+
+@patch('version_selector.available_versions_from_url')
+def test_version_selector_leap(mock_available_versions):
+    # Arrange
+    mock_available_versions.return_value = ["v1"]
+
+    # Act
+    result = version_selector.available_versions("leap")
+
+    # Assert
+    assert result == ["v1"]
+    mock_available_versions.assert_called_once_with(
+        "https://api.github.com/repos/antelopeio/leap/releases")
+
+
+@patch('version_selector.available_versions_from_url')
+def test_version_selector_cdt(mock_available_versions):
+    # Arrange
+    mock_available_versions.return_value = ["v1", "v2"]
+
+    # Act
+    result = version_selector.available_versions("CdT")
+
+    # Assert
+    assert result == ["v1", "v2"]
+    mock_available_versions.assert_called_once_with(
+        "https://api.github.com/repos/antelopeio/cdt/releases")
+
+
+class test_version_selector(TestCase):
+    @patch('version_selector.available_versions')
+    @patch('builtins.input')
+    def test_version_selector_exit_low(self, mock_input, mock_available_versions):
+        mock_input.return_value = "0"
+        mock_available_versions.return_value = ["v1", "v2"]
+
+        with self.assertRaises(SystemExit):
+            version_selector.get_version("leap")
+
+    @patch('version_selector.available_versions')
+    @patch('builtins.input')
+    def test_version_selector_exit_high(self, mock_input, mock_available_versions):
+        mock_input.return_value = "3"
+        mock_available_versions.return_value = ["v1", "v2"]
+
+        with self.assertRaises(SystemExit):
+            version_selector.get_version("leap")
+
+    @patch('version_selector.available_versions')
+    @patch('builtins.input')
+    def test_version_selector_exit_invalid(self, mock_input, mock_available_versions):
+        mock_input.return_value = "abc"
+        mock_available_versions.return_value = ["v1", "v2"]
+
+        with self.assertRaises(SystemExit):
+            version_selector.get_version("cdt")


### PR DESCRIPTION
If user will run `dune --leap` or `dune --cdt` without version then list of available options will be displayed like on example below:
```
mikel@msi:~/repo/DUNE$ ./dune --leap 
Available Leap versions:
1) v3.2.1
2) v3.1.4
3) v3.2.0
4) v3.2.0-rc2
5) v3.1.3
6) v3.2.0-rc1
7) v3.1.2
8) v3.1.1
9) v3.1.0
10) v3.1.0-rc4
Enter which version you want to choose [1,10]? 1
```