### PR TITLE
Add warning if some DUNE arguments were unused

### DIFF
--- a/src/dune/__main__.py
+++ b/src/dune/__main__.py
@@ -82,6 +82,7 @@ if __name__ == '__main__':
     if parser.is_forwarding():
         dune_sys.execute_interactive_cmd(parser.get_forwarded_args())
     else:
+        WAS_REMAINDER_ARGS_USED = False
 
         try:
             if args.start is not None:
@@ -184,15 +185,16 @@ if __name__ == '__main__':
                                       False)
 
             elif args.cmake_build is not None:
-                dune_sys.build_cmake_proj(args.cmake_build[0],
-                                          parse_optional(args.remainder))
+                commands, WAS_REMAINDER_ARGS_USED = parse_optional(args.remainder)
+                dune_sys.build_cmake_proj(args.cmake_build[0], commands)
 
             elif args.ctest is not None:
-                dune_sys.ctest_runner(args.ctest[0],
-                                      parse_optional(args.remainder))
+                commands, WAS_REMAINDER_ARGS_USED = parse_optional(args.remainder)
+                dune_sys.ctest_runner(args.ctest[0], commands)
 
             elif args.gdb is not None:
-                dune_sys.gdb(args.gdb[0], parse_optional(args.remainder))
+                commands, WAS_REMAINDER_ARGS_USED = parse_optional(args.remainder)
+                dune_sys.gdb(args.gdb[0], commands)
 
             elif args.deploy is not None:
                 dune_sys.deploy_contract(
@@ -252,6 +254,9 @@ if __name__ == '__main__':
             else:
                 for module in modules:
                     module.handle_args(args)
+
+            if args.remainder and WAS_REMAINDER_ARGS_USED is False:
+                print('Warning: following arguments were possibly unused: ' + str(args.remainder))
 
         except KeyboardInterrupt:
             pass

--- a/src/dune/args.py
+++ b/src/dune/args.py
@@ -34,8 +34,8 @@ def fix_args(args):
 
 def parse_optional(cmd):
     if cmd is not None:
-        return cmd[1:]  # remove leading --
-    return cmd  # empty list
+        return cmd[1:], True  # remove leading --
+    return cmd, True  # empty list
 
 
 class arg_parser:

--- a/tests/test_remainder.py
+++ b/tests/test_remainder.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+"""Test DUNE args remainder
+
+This script tests if there is a warning if user passes
+unused arguments to DUNE
+"""
+
+import subprocess
+
+from common import DUNE_EXE
+from container import container
+
+
+def test_unused():
+    """Test the warning for unused arguments"""
+
+    # Remove any container that already exists.
+    cntr = container('dune_container', 'dune:latest')
+    if cntr.exists():
+        subprocess.run([DUNE_EXE, "--destroy-container"], check=True)
+
+    # List of expected values.
+    expect_list = \
+        [
+            b"Warning: following arguments were possibly unused: ['config.ini']",
+        ]
+
+    # Call DUNE with improper arguments
+    completed_process = subprocess.run([DUNE_EXE,"--start", "my_node", "config.ini"], check=True, stdout=subprocess.PIPE)
+
+    # Test for expected values in the captured output.
+    for expect in expect_list:
+        assert expect in completed_process.stdout
+
+def test_no_warning():
+    """Test there is no warning for arguments using remainder in i.e. gdb case"""
+
+    # List of expected values.
+    unexpected_list = \
+        [
+            b'Warning: following arguments were possibly unused:',
+        ]
+
+    # Call DUNE.
+    completed_process = subprocess.run([DUNE_EXE,"--gdb", "/usr/bin/echo", "Hello"], check=True, stdout=subprocess.PIPE)
+
+    # Test values are NOT in the captured output.
+    for unexpected in unexpected_list:
+        assert unexpected not in completed_process.stdout


### PR DESCRIPTION
Example:
```
mikel@msi:~/repo/DUNE$ ./dune --start my_node config.ini
Node [my_node] is already running.
Warning: following arguments were possibly unused: ['config.ini']
```
There are cases that unused arguments will be used by DUNE external modules / plugins / extensions, that is why in the warning "possibly" word is used.
