### PR TITLE
Finish bootstrap initialization by adding example currency: SYS

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ This command takes a compatible name for the new Antelope account and an optiona
 
 ---
 
+**--system-newaccount** 
+This will create a new account on the blockchain with initial resources using command `cleos system newaccount`
+
+---
+
 **--create-cmake-app** 
 This will produce a new smart contract project that utilizes CMake as its build system. This command takes a project name and a directory.
 

--- a/src/dune/__main__.py
+++ b/src/dune/__main__.py
@@ -174,6 +174,26 @@ if __name__ == '__main__':
                 else:
                     dune_sys.create_account(args.create_account[0])
 
+            elif args.system_newaccount is not None:
+                commands, WAS_REMAINDER_ARGS_USED = parse_optional(args.remainder)
+
+                if len(args.system_newaccount) > 3 and WAS_REMAINDER_ARGS_USED:
+                    dune_sys.system_newaccount(args.system_newaccount[0],
+                                            args.system_newaccount[1],
+                                            args.system_newaccount[2],
+                                            args.system_newaccount[3],
+                                            commands)
+                elif len(args.system_newaccount) > 3:
+                    dune_sys.system_newaccount(args.system_newaccount[0],
+                                            args.system_newaccount[1],
+                                            args.system_newaccount[2],
+                                            args.system_newaccount[3])
+                elif len(args.system_newaccount) > 1:
+                    dune_sys.system_newaccount(args.system_newaccount[0],
+                                            args.system_newaccount[1])
+                else:
+                    dune_sys.system_newaccount(args.system_newaccount[0])
+
             elif args.create_cmake_app is not None:
                 dune_sys.init_project(args.create_cmake_app[0],
                                       dune_sys.docker.abs_host_path(

--- a/src/dune/args.py
+++ b/src/dune/args.py
@@ -84,6 +84,12 @@ class arg_parser:
                                            "PRIV_KEY (Optional)"],
                                   help='create an EOSIO account and an optional creator (the '
                                        'default is eosio)')
+        self._parser.add_argument('--system-newaccount', nargs='+',
+                                  metavar=["NAME", "CREATOR (Optional)", "PUB_KEY (Optional)",
+                                           "PRIV_KEY (Optional)", "-- FLAGS (Optional)"],
+                                  help='create an EOSIO account with initial resources using'
+                                       '"cleos system newaccount" command. '
+                                       'Optional flags are of the form -- --buy-ram-bytes 3000')
         self._parser.add_argument('--create-cmake-app', nargs=2, metavar=["PROJ_NAME", "DIR"],
                                   help='create a smart contract project at from a specific host '
                                        'location')


### PR DESCRIPTION
According to https://docs.eosnetwork.com/docs/latest/tutorials/bios-boot-sequence bootstrapping should have a currency / token created and issued.

I have added example "SYS" currency so the bootstrapping is finished and i.e. new accounts could be created.

In the future EOS specific stuff (i.e. bootstrapping together with creating SYS token) should be moved to plugins - there will be a separate issue for that.