### PR TITLE
Nodeos should have log file now

### DIFF
--- a/scripts/start_node.sh
+++ b/scripts/start_node.sh
@@ -1,8 +1,8 @@
-#! /bin/sh
+#! /bin/bash
 
 # 1 - data directory
 # 2 - config.ini directory
 # 3 - snapshot
 # 4 - node name
 
-nodeos --data-dir=$1 --config-dir=$2 $3 &> /app/$4.out
+nodeos --data-dir=$1 --config-dir=$2 $3 >/app/$4.out 2>&1 &

--- a/src/dune/dune.py
+++ b/src/dune/dune.py
@@ -108,7 +108,7 @@ class dune:
             print("Node [" + nod.name() + "] is already running.")
             return
 
-        cmd = ['sh', 'start_node.sh', nod.data_dir(), nod.config_dir()]
+        cmd = ['bash', 'start_node.sh', nod.data_dir(), nod.config_dir()]
 
         if snapshot is not None:
             cmd = cmd + ['--snapshot /app/nodes/' + nod.name() + '/snapshots/' + snapshot + ' -e']
@@ -144,14 +144,16 @@ class dune:
                 self.stop_node(node(ctx.active))
 
         stdout, stderr, exit_code = self._docker.execute_cmd(cmd + [nod.name()])
+        print(stdout)
+        print(stderr)
 
-        if exit_code == 0:
+        if exit_code == 0 and self.is_node_running(nod):
             self.set_active(nod)
             print("Active [" + nod.name() + "]")
-            print(stdout)
-            print(stderr)
         else:
-            print(stderr)
+            print("ERROR: " + nod.name() + " is not running!")
+
+        self._docker.execute_cmd2(['cat', '/app/' + nod.name() + '.out'])
 
     def cleos_cmd(self, cmd, quiet=True):
         self.unlock_wallet()


### PR DESCRIPTION
Logs are now accessible in docker. I have also left the functionality, where after starting a new node the new log file is printed on the screen.

```
mikel@msi:~/repo/DUNE$ ./dune --start my_node
Node [my_node] is already running.
mikel@msi:~/repo/DUNE$ ./dune -- ls -la /app/my_node.out
-rw-r--r-- 1 root root 50610 Mar  3 10:42 /app/my_node.out
mikel@msi:~/repo/DUNE$ ./dune -- head /app/my_node.out && tail /app/my_node.out
APPBASE: Warning: The following configuration items in the config.ini file are redundantly set to
         their default value:
             abi-serializer-max-time-ms, http-server-address, p2p-listen-endpoint, net-threads, 
             state-history-endpoint
         Explicit values will override future changes to application defaults. Consider commenting out or
         removing these items.
info  2023-03-03T10:41:46.628 nodeos    chain_plugin.cpp:657          plugin_initialize    ] initializing chain plugin
info  2023-03-03T10:41:46.628 nodeos    chain_plugin.cpp:466          operator()           ] Support for builtin protocol feature 'GET_BLOCK_NUM' (with digest of '35c2186cc36f7bb4aeaf4487b36e57039ccf45a9136aa856a5d569ecca55ef2b') is enabled with preactivation required
info  2023-03-03T10:41:46.628 nodeos    chain_plugin.cpp:574          operator()           ] Saved default specification for builtin protocol feature 'GET_BLOCK_NUM' (with digest of '35c2186cc36f7bb4aeaf4487b36e57039ccf45a9136aa856a5d569ecca55ef2b') to: /app/nodes/my_node/protocol_features/BUILTIN-GET_BLOCK_NUM.json
info  2023-03-03T10:41:46.628 nodeos    chain_plugin.cpp:466          operator()           ] Support for builtin protocol feature 'CRYPTO_PRIMITIVES' (with digest of '6bcb40a24e49c26d0a60513b6aeb8551d264e4717f306b81a37a5afb3b47cedc') is enabled with preactivation required
mikel@msi:~/repo/DUNE$ ./dune -- tail /app/my_node.out
info  2023-03-03T10:43:24.902 nodeos    producer_plugin.cpp:2534      produce_block        ] Produced block 518092ccf4331f1b... #197 @ 2023-03-03T10:43:25.000 signed by eosio [trxs: 0, lib: 196, confirmed: 0, net: 0, cpu: 100, elapsed: 76, time: 1587]
(...)
info  2023-03-03T10:43:29.300 nodeos    producer_plugin.cpp:2534      produce_block        ] Produced block 885bcf9060f7297b... #206 @ 2023-03-03T10:43:29.500 signed by eosio [trxs: 0, lib: 205, confirmed: 0, net: 0, cpu: 100, elapsed: 59, time: 606]
```