### PR TITLE
Add temporary fix for Chocolatey Package Verifier

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r ../../requirements.txt; fi
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - shell: bash

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest requests argcomplete
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements.txt ]; then pip install -r ../../requirements.txt; fi
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - shell: bash

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ After installation open `cmd.exe` and verify `python --version` returns current 
 4. Run following commands:
 ```
 choco uninstall antelopeio-dune -y
-choco install python docker-desktop -y
+choco install netfx-4.8 python docker-desktop -y
 choco install .\antelopeio-dune.1.1.0.nupkg -y
 ```
 5. Restart your computer (this is because %PATH% has to be reloaded. In cmd.exe it is enough to run command `refreshenv`).

--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ After installation open `cmd.exe` and verify `python --version` returns current 
 4. Run following commands:
 ```
 choco uninstall antelopeio-dune -y
-choco install netfx-4.8 python docker-desktop -y
+choco install netfx-4.8 python311 docker-desktop -y
+```
+5. Now restart PowerShell as administrator again (so that `python` command could be executed) and run:
+```
 choco install .\antelopeio-dune.1.1.0.nupkg -y
 ```
 5. Restart your computer (this is because %PATH% has to be reloaded. In cmd.exe it is enough to run command `refreshenv`).

--- a/packaging/antelopeio-dune/antelopeio-dune.nuspec
+++ b/packaging/antelopeio-dune/antelopeio-dune.nuspec
@@ -22,6 +22,8 @@ Docker Utilities for Node Execution (DUNE) is a tool to abstract over Leap progr
     <dependencies>
       <dependency id="python"/>
       <dependency id="docker-desktop"/>
+	  <!-- Below was added as a workaround for Chocolatey CI Package Verifier which tried to install netfx-4.8.1 not compatible with Windows Server 2019  -->
+      <dependency id="netfx-4.8"/>
     </dependencies>
   </metadata>
   <files>

--- a/packaging/antelopeio-dune/antelopeio-dune.nuspec
+++ b/packaging/antelopeio-dune/antelopeio-dune.nuspec
@@ -20,7 +20,7 @@ Docker Utilities for Node Execution (DUNE) is a tool to abstract over Leap progr
     
     </description>
     <dependencies>
-      <dependency id="python"/>
+      <dependency id="python311"/>
       <dependency id="docker-desktop"/>
 	  <!-- Below was added as a workaround for Chocolatey CI Package Verifier which tried to install netfx-4.8.1 not compatible with Windows Server 2019  -->
       <dependency id="netfx-4.8"/>

--- a/packaging/antelopeio-dune/chocolateyinstall.ps1
+++ b/packaging/antelopeio-dune/chocolateyinstall.ps1
@@ -3,3 +3,5 @@ $ErrorActionPreference = 'Stop'; # stop on all errors
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name Path -Value "$toolsDir;$($env:Path)"
+
+python -m pip install --exists-action i --disable-pip-version-check -r $toolsDir/requirements.txt

--- a/packaging/generate_chocolatey.bat
+++ b/packaging/generate_chocolatey.bat
@@ -23,6 +23,8 @@ mkdir %target-dir%\scripts\
 xcopy "%script-path%"\..\scripts\* %target-dir%\scripts\ /e /k /h /i
 mkdir %target-dir%\tests\
 xcopy "%script-path%"\..\tests\* %target-dir%\tests\ /e /k /h /i
+REM Chocolatey packages cannot contain git files
+del %target-dir%\tests\.gitignore
 mkdir %target-dir%\plugin_example\
 xcopy "%script-path%"\..\plugin_example\* %target-dir%\plugin_example\ /e /k /h /i
 mkdir %target-dir%\docs\

--- a/packaging/generate_chocolatey.bat
+++ b/packaging/generate_chocolatey.bat
@@ -16,6 +16,7 @@ copy "%script-path%"\..\dune* %target-dir%
 copy "%script-path%"\..\Dockerfile* %target-dir%
 copy "%script-path%"\..\bootstrap* %target-dir%
 copy "%script-path%"\..\README* %target-dir%
+copy "%script-path%"\..\requirements.txt %target-dir%
 
 mkdir %target-dir%\src\
 xcopy "%script-path%"\..\src\* %target-dir%\src /e /k /h /i

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+argcomplete
+pytest
+requests


### PR DESCRIPTION
Now automatic package verification is passing: https://community.chocolatey.org/packages/antelopeio-dune/1.1.0

I'm not sure where this issue should be actually fixed - either on Chocolatey CI Package Verification side or in Docker Desktop Chocolatey package (Docker Desktop requires .NET). Anyway I'm adding the temporary solution to our package.