### PR TITLE
Ignore src/plugin/dune_hello.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 
+src/plugin/dune_hello/*
+
 # Translations
 *.mo
 *.pot


### PR DESCRIPTION
It keeps getting committed when tests fail or are interrupted. 