### PR TITLE
Upgrade reference-contract to newest version

### DIFF
--- a/scripts/bootstrap_contracts.sh
+++ b/scripts/bootstrap_contracts.sh
@@ -4,7 +4,6 @@
 rm -rf reference-contracts || true
 git clone https://github.com/"${ORG}"/reference-contracts
 cd reference-contracts
-git checkout 074bc11394d13395e82015f6c41db32a67170d73
 mkdir build
 cd build
 cmake ..


### PR DESCRIPTION
Resolves #194
Now we are always taking the latest CDT, leap and reference-contracts. 

Setting to fixed versions will happen in separate issue: https://github.com/AntelopeIO/DUNE/issues/182