### PR TITLE
Allow Dunes --config to have a customized .ini file for configuration

### DIFF
--- a/docs/man/dunes.1
+++ b/docs/man/dunes.1
@@ -47,7 +47,15 @@ Start a new node with a given name
 .IP
 .nf
 \f[C]
-Optionally used with --start, a path containing the config.ini file to use.
+Optionally used with --start, a directory containing the config.ini file or the full path containing the .ini file to use.
+\f[R]
+.fi
+.PP
+\f[B]\f[CB]--rmdirtydb\f[B]\f[R]
+.IP
+.nf
+\f[C]
+Optionally used with --start to clean a database dirty flag of nodeos which was set likely due to unclean shutdown
 \f[R]
 .fi
 .PP

--- a/docs/man/dunes.1.md
+++ b/docs/man/dunes.1.md
@@ -37,7 +37,11 @@ contracts on Antelope blockchains.
 
 **`-c <CONFIG_DIR>, --config <CONFIG_DIR>`**
 
-    Optionally used with --start, a path containing the config.ini file to use.
+    Optionally used with --start, a directory containing the config.ini file or the full path containing the .ini file to use.
+
+**`--rmdirtydb`**
+
+    Optionally used with --start to clean a database dirty flag of nodeos which was set likely due to unclean shutdown
 
 **`--stop <NODE>`**
 

--- a/src/dunes/__main__.py
+++ b/src/dunes/__main__.py
@@ -133,16 +133,16 @@ if __name__ == '__main__':
                 elif len(args.config) == 1:
                     cfg_temp = args.config[0]
                     if not os.path.exists(cfg_temp):
-                        parser.exit_with_help_message("--config: config.ini unknown path\n",
+                        parser.exit_with_help_message("--config: .ini unknown path\n",
                                                        "bad value: ", cfg_temp)
                     if os.path.isdir(cfg_temp):
                         cfg_temp = os.path.join(cfg_temp, "config.ini")
-                    if os.path.split(cfg_temp)[1] != "config.ini":
-                        parser.exit_with_help_message("--config: config must either be a config.ini"
-                                                      "file or a path containg one\n"
+                    if os.path.splitext(cfg_temp)[1] !=".ini":
+                        parser.exit_with_help_message("--config: config must either be a directory that has config.ini\n"
+                                                      "or a full path including a file name with .ini extension \n"
                                                       "bad value: ", cfg_temp)
                     if not os.path.exists(cfg_temp):
-                        parser.exit_with_help_message("--config: config.ini file must exist\n"
+                        parser.exit_with_help_message("--config: .ini file must exist\n"
                                                       "bad value: ", cfg_temp)
                     n = node(args.start[0], dunes_sys.docker.abs_host_path(cfg_temp))
                 else:

--- a/src/dunes/args.py
+++ b/src/dunes/args.py
@@ -49,8 +49,8 @@ class arg_parser:
         self._parser.add_argument('-s', '--start', nargs=1, metavar="<NODE>",
                                   help='start a new node with a given name.')
         self._parser.add_argument('-c', '--config', nargs=1, metavar="<CONFIG_DIR>",
-                                  help='optionally used with --start, a path containing'
-                                  ' the config.ini file to use')
+                                  help='optionally used with --start, a directory containing'
+                                  ' the config.ini file or the full path containing the .ini file to use')
         self._parser.add_argument('--rmdirtydb', action='store_true',
                                   help='optionally used with --start to clean a database dirty flag of nodeos'
                                   ' which was set likely due to unclean shutdown')

--- a/src/dunes/dunes.py
+++ b/src/dunes/dunes.py
@@ -149,8 +149,10 @@ class dunes:
             nod.set_config('/app/config.ini')
 
         if nod.config() is not None:
-            self._docker.execute_cmd(['cp', nod.config(), nod.config_dir()])
-            print("Using Configuration [" + nod.config() + "]")
+            # a customized .ini file such as mycustconfig001.ini will be copied to config_dir as config.ini
+            node_config_filename = nod.config_dir() + "/config.ini"
+            self._docker.execute_cmd(['cp', nod.config(), node_config_filename])
+            print("Using Configuration [" + nod.config() + "], which is copied to [" + node_config_filename + "]")
 
         self.stop_conflicting_nodes(nod)
 

--- a/tests/mycustconfig001.ini
+++ b/tests/mycustconfig001.ini
@@ -1,0 +1,26 @@
+wasm-runtime = eos-vm
+abi-serializer-max-time-ms = 15
+chain-state-db-size-mb = 65536
+# chain-threads = 2
+contracts-console = true
+http-server-address = 0.0.0.0:9996
+p2p-listen-endpoint = 0.0.0.0:9997
+state-history-endpoint = 0.0.0.0:9998
+verbose-http-errors = true
+# http-threads = 2
+agent-name = "DUNES Customized Test Node"
+net-threads = 2
+max-transaction-time = 100
+read-only-read-window-time-us = 120000
+producer-name = eosio
+enable-stale-production = true
+# producer-threads = 2
+# trace-history = false
+# chain-state-history = false
+resource-monitor-not-shutdown-on-threshold-exceeded = true
+http-validate-host = false
+
+plugin = eosio::chain_api_plugin
+plugin = eosio::http_plugin
+plugin = eosio::producer_plugin
+plugin = eosio::producer_api_plugin

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -264,7 +264,7 @@ def test_nodes():
     subprocess.run([DUNES_EXE, "--start", NODE_BRAVO, "--config", CONFIG_FILE], check=True)
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, True, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
-    
+
     subprocess.run([DUNES_EXE,"--stop", NODE_BRAVO], check=True)
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, True,  False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
@@ -273,7 +273,7 @@ def test_nodes():
     subprocess.run([DUNES_EXE, "--start", NODE_BRAVO, "--config", CONFIG_FILE_CUST], check=True)
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, True, True, ALT_HTTP_ADDR_CUST, ALT_P2P_ADDR_CUST, ALT_SHIP_ADDR_CUST]])
-    
+
     # stop and then start NODE_BRAVO again using standard config.ini
     subprocess.run([DUNES_EXE,"--stop", NODE_BRAVO], check=True)
     subprocess.run([DUNES_EXE, "--start", NODE_BRAVO, "--config", CONFIG_FILE], check=True)
@@ -494,7 +494,7 @@ def test_node_start_rmdirtydb():
     subprocess.run([DUNES_EXE,"--start", NODE_BRAVO, "--config", CONFIG_FILE, "--rmdirtydb"], check=True)
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, True, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
-    
+
     subprocess.run([DUNES_EXE,"--stop", NODE_BRAVO], check=True)
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, True,  False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -31,12 +31,16 @@ NODE_CHARLIE = "CHARLIE_NODE"
 
 CONFIG_PATH = TEST_PATH
 CONFIG_FILE = TEST_PATH + "/config.ini"
+CONFIG_FILE_CUST = TEST_PATH + "/mycustconfig001.ini"
 
 EXPORT_DIR = TEST_PATH + "/temp"
 
 ALT_HTTP_ADDR="0.0.0.0:9991"
 ALT_P2P_ADDR="0.0.0.0:9992"
 ALT_SHIP_ADDR="0.0.0.0:9993"
+ALT_HTTP_ADDR_CUST="0.0.0.0:9996"
+ALT_P2P_ADDR_CUST="0.0.0.0:9997"
+ALT_SHIP_ADDR_CUST="0.0.0.0:9998"
 
 
 def remove_all():
@@ -256,7 +260,22 @@ def test_nodes():
     subprocess.run([DUNES_EXE, "--start", NODE_ALPHA, "--config", CONFIG_PATH], check=True)
     validate_node_list([[NODE_ALPHA, True, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
 
-    # Test `--start` where start includes a config file.
+    # Test `--start` where start includes a config file named config.ini
+    subprocess.run([DUNES_EXE, "--start", NODE_BRAVO, "--config", CONFIG_FILE], check=True)
+    validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
+                        [NODE_BRAVO, True, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
+    
+    subprocess.run([DUNES_EXE,"--stop", NODE_BRAVO], check=True)
+    validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
+                        [NODE_BRAVO, True,  False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
+
+    # Test `--start` where start includes a config file with customized name mycustconfig001.ini
+    subprocess.run([DUNES_EXE, "--start", NODE_BRAVO, "--config", CONFIG_FILE_CUST], check=True)
+    validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
+                        [NODE_BRAVO, True, True, ALT_HTTP_ADDR_CUST, ALT_P2P_ADDR_CUST, ALT_SHIP_ADDR_CUST]])
+    
+    # stop and then start NODE_BRAVO again using standard config.ini
+    subprocess.run([DUNES_EXE,"--stop", NODE_BRAVO], check=True)
     subprocess.run([DUNES_EXE, "--start", NODE_BRAVO, "--config", CONFIG_FILE], check=True)
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, True, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
@@ -471,9 +490,19 @@ def test_node_start_rmdirtydb():
     subprocess.run([DUNES_EXE,"--start", NODE_ALPHA, "--config", CONFIG_PATH, "--rmdirtydb"], check=True)
     validate_node_list([[NODE_ALPHA, True, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
 
+    # use standard config.ini
     subprocess.run([DUNES_EXE,"--start", NODE_BRAVO, "--config", CONFIG_FILE, "--rmdirtydb"], check=True)
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, True, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
+    
+    subprocess.run([DUNES_EXE,"--stop", NODE_BRAVO], check=True)
+    validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
+                        [NODE_BRAVO, True,  False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
+
+    # use customized .ini
+    subprocess.run([DUNES_EXE, "--start", NODE_BRAVO, "--config", CONFIG_FILE_CUST, "--rmdirtydb"], check=True)
+    validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
+                        [NODE_BRAVO, True, True, ALT_HTTP_ADDR_CUST, ALT_P2P_ADDR_CUST, ALT_SHIP_ADDR_CUST]])
 
      # Finally, clean everything up before final return.
     remove_all()


### PR DESCRIPTION
Currently, dune --start <node> --config <path> could be better.
--help reports must be a path containing config.ini. But code accepts either that OR a path to a config.ini.
As an enhancement, we should accept either a path containing config.ini OE a path to a file with the extension .ini.