### PR TITLE
Fix tests on Windows

### DIFF
--- a/scripts/my_init
+++ b/scripts/my_init
@@ -338,7 +338,7 @@ try:
 	main(args)
 except KeyboardInterrupt:
 	warn("Init system aborted.")
-	exit(2)
+	sys.exit(2)
 finally:
 	if args.kill_all_on_exit:
 		kill_all_processes(KILL_ALL_PROCESSES_TIMEOUT)

--- a/tests/test_antler_proj.py
+++ b/tests/test_antler_proj.py
@@ -26,7 +26,7 @@ import pytest
 from common import DUNES_EXE, TEST_PATH
 
 
-TEST_PROJECT_DIR = TEST_PATH + "/" + "antler_test_dir"
+TEST_PROJECT_DIR = os.path.join(TEST_PATH, "antler_test_dir")
 
 
 def remove_existing():

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -19,9 +19,9 @@ NODE_NAME = "my_node"
 ACCT_NAME = "myaccount"
 
 PROJECT_NAME = "test_app"
-TEST_APP_DIR = TEST_PATH + "/" + PROJECT_NAME
-TEST_APP_BLD_DIR = TEST_APP_DIR + "/build/" + PROJECT_NAME
-TEST_APP_WASM = TEST_APP_BLD_DIR + "/" + PROJECT_NAME + ".wasm"    # TEST_APP_BLD_DIR + "/test_app.wasm"
+TEST_APP_DIR = os.path.join(TEST_PATH, PROJECT_NAME)
+TEST_APP_BLD_DIR = os.path.join(TEST_APP_DIR, *["build", PROJECT_NAME])
+TEST_APP_WASM = os.path.join(TEST_APP_BLD_DIR, PROJECT_NAME + ".wasm")    # TEST_APP_BLD_DIR/test_app.wasm
 
 
 @pytest.mark.destructive

--- a/tests/test_list_features.py
+++ b/tests/test_list_features.py
@@ -19,31 +19,31 @@ def test_list_features():
 
     # List of expected output lines from `dunes --list-features`.
     expect_list = \
-	[b"GET_CODE_HASH",
-        b"CRYPTO_PRIMITIVES",
-        b"GET_BLOCK_NUM",
-        b"ACTION_RETURN_VALUE",
-        b"CONFIGURABLE_WASM_LIMITS2",
-        b"BLOCKCHAIN_PARAMETERS",
-        b"GET_SENDER",
-        b"FORWARD_SETCODE",
-        b"ONLY_BILL_FIRST_AUTHORIZER",
-        b"RESTRICT_ACTION_TO_SELF",
-        b"DISALLOW_EMPTY_PRODUCER_SCHEDULE",
-        b"FIX_LINKAUTH_RESTRICTION",
-        b"REPLACE_DEFERRED",
-        b"NO_DUPLICATE_DEFERRED_ID",
-        b"ONLY_LINK_TO_EXISTING_PERMISSION",
-        b"RAM_RESTRICTIONS",
-        b"WEBAUTHN_KEY",
-        b"WTMSIG_BLOCK_SIGNATURES"]
+	["GET_CODE_HASH",
+        "CRYPTO_PRIMITIVES",
+        "GET_BLOCK_NUM",
+        "ACTION_RETURN_VALUE",
+        "CONFIGURABLE_WASM_LIMITS2",
+        "BLOCKCHAIN_PARAMETERS",
+        "GET_SENDER",
+        "FORWARD_SETCODE",
+        "ONLY_BILL_FIRST_AUTHORIZER",
+        "RESTRICT_ACTION_TO_SELF",
+        "DISALLOW_EMPTY_PRODUCER_SCHEDULE",
+        "FIX_LINKAUTH_RESTRICTION",
+        "REPLACE_DEFERRED",
+        "NO_DUPLICATE_DEFERRED_ID",
+        "ONLY_LINK_TO_EXISTING_PERMISSION",
+        "RAM_RESTRICTIONS",
+        "WEBAUTHN_KEY",
+        "WTMSIG_BLOCK_SIGNATURES"]
 
     # Convert the list to a useful comparison value.
-    expect = b''
+    expect = ''
     for temp in expect_list:
-        expect = expect + temp + b'\n'
+        expect = expect + temp + '\n'
 
     # Call the tool, check return code, check expected value.
     completed_process = subprocess.run([DUNES_EXE, "--list-features"],
                                        check=True, stdout=subprocess.PIPE)
-    assert completed_process.stdout == expect
+    assert completed_process.stdout.decode().replace('\r', '') == expect

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -33,7 +33,7 @@ NODE_CHARLIE = "CHARLIE_NODE"
 
 CONFIG_PATH = TEST_PATH
 CONFIG_FILE = os.path.join(TEST_PATH, "config.ini")
-CONFIG_FILE_CUST = os.path.join(TEST_PATH, "/mycustconfig001.ini")
+CONFIG_FILE_CUST = os.path.join(TEST_PATH, "mycustconfig001.ini")
 
 EXPORT_DIR = os.path.join(TEST_PATH, "temp")
 
@@ -53,7 +53,7 @@ def remove_all():
                                        check=True, stdout=subprocess.PIPE)
 
     # Convert the captured stdin to a list.
-    result_list = completed_process.stdout.decode().split("\n")
+    result_list = completed_process.stdout.decode().replace('\r', '').split("\n")
 
     # Remove the header.
     result_list.pop(0)
@@ -98,7 +98,7 @@ def validate_node_state( node_name, active_state, running_state ):
                                        check=True, stdout=subprocess.PIPE)
 
     # Convert the captured stdin to a list for comparison with expected output.
-    result_list = completed_process.stdout.decode().split("\n")
+    result_list = completed_process.stdout.decode().replace('\r', '').split("\n")
 
     assert expect in result_list
 
@@ -177,7 +177,7 @@ def validate_node_list( node_list ):
                                        check=True, stdout=subprocess.PIPE)
 
     # Convert the captured stdin to a list for comparison with expected output.
-    result_list = completed_process.stdout.decode().split("\n")
+    result_list = completed_process.stdout.decode().replace('\r', '').split("\n")
 
     # Iterate over the elements in the results list
     for entry in result_list:
@@ -202,7 +202,7 @@ def expect_empty_verbose_list():
 
     # Call the tool, check expected value.
     completed_process = subprocess.run([DUNES_EXE, "--list"], check=True, stdout=subprocess.PIPE)
-    assert completed_process.stdout.decode() == empty_verbose_list
+    assert completed_process.stdout.decode().replace('\r', '') == empty_verbose_list
 
 
 # pylint: disable=too-many-statements
@@ -243,13 +243,15 @@ def test_nodes():
 
     # Test --get-active shows NODE_BRAVO
     #   Tests `--get-active`.
-    assert subprocess.run([DUNES_EXE, "--get-active"], check=True, stdout=subprocess.PIPE).stdout.decode() == (NODE_BRAVO + "\n")
+    assert subprocess.run([DUNES_EXE, "--get-active"], check=True, stdout=subprocess.PIPE).stdout.decode().replace('\r', '') \
+        == (NODE_BRAVO + "\n")
 
     # Test --set-active works to switch to NODE_ALPHA and --get active returns the correct value.
     #   Tests `--set-active` switch active node while run state is left unchanged.
     subprocess.run([DUNES_EXE, "--set-active", NODE_ALPHA], check=True)
     validate_node_list([[NODE_ALPHA, True, False],[NODE_BRAVO, False, True]]) # Note this is TF,FT
-    assert subprocess.run([DUNES_EXE, "--get-active"], check=True, stdout=subprocess.PIPE).stdout.decode() == (NODE_ALPHA + "\n")
+    assert subprocess.run([DUNES_EXE, "--get-active"], check=True, stdout=subprocess.PIPE).stdout.decode().replace('\r', '') \
+        == (NODE_ALPHA + "\n")
 
     # Remove NODE_ALPHA, ensure it is no longer in the list.
     #   Tests `--remove`.
@@ -319,7 +321,7 @@ def test_nodes():
 
     # Test --export-node using standard filename.
     subprocess.run([DUNES_EXE, "--export-node", NODE_ALPHA, EXPORT_DIR], check=True)
-    assert os.path.exists( os.path.join(EXPORT_DIR,  NODE_ALPHA+".tgz")
+    assert os.path.exists( os.path.join(EXPORT_DIR,  NODE_ALPHA+".tgz") )
 
     # Below check documents current behavior: node_bravo is active, however before exporting node_charlie was active.
     # Fix this in issue https://github.com/AntelopeIO/DUNES/issues/159
@@ -397,13 +399,15 @@ def test_start_active_node():
 
     # Test --get-active shows NODE_BRAVO
     #   Tests `--get-active`.
-    assert subprocess.run([DUNES_EXE, "--get-active"], check=True, stdout=subprocess.PIPE).stdout.decode() == (NODE_CHARLIE + "\n")
+    assert subprocess.run([DUNES_EXE, "--get-active"], check=True, stdout=subprocess.PIPE).stdout.decode().replace('\r', '') \
+        == (NODE_CHARLIE + "\n")
 
     # Test --set-active works to switch to NODE_ALPHA and --get active returns the correct value.
     #   Tests `--set-active` switch active node while run state is left unchanged.
     subprocess.run([DUNES_EXE, "--set-active", NODE_ALPHA], check=True)
     validate_node_list([[NODE_ALPHA, True, False], [NODE_BRAVO, False, False], [NODE_CHARLIE, False, True]]) # Note this is TF,FT
-    assert subprocess.run([DUNES_EXE, "--get-active"], check=True, stdout=subprocess.PIPE).stdout.decode() == (NODE_ALPHA + "\n")
+    assert subprocess.run([DUNES_EXE, "--get-active"], check=True, stdout=subprocess.PIPE).stdout.decode().replace('\r', '') \
+        == (NODE_ALPHA + "\n")
 
     # Make sure you can start active node
     subprocess.run([DUNES_EXE, "--start", NODE_ALPHA], check=True)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -16,6 +16,7 @@ This script tests that the compiled binary produce expected output for these com
 """
 
 
+import os
 import shutil                   # rmtree
 import subprocess
 import pytest
@@ -31,10 +32,10 @@ NODE_BRAVO = "BRAVO_NODE"
 NODE_CHARLIE = "CHARLIE_NODE"
 
 CONFIG_PATH = TEST_PATH
-CONFIG_FILE = TEST_PATH + "/config.ini"
-CONFIG_FILE_CUST = TEST_PATH + "/mycustconfig001.ini"
+CONFIG_FILE = os.path.join(TEST_PATH, "config.ini")
+CONFIG_FILE_CUST = os.path.join(TEST_PATH, "/mycustconfig001.ini")
 
-EXPORT_DIR = TEST_PATH + "/temp"
+EXPORT_DIR = os.path.join(TEST_PATH, "temp")
 
 ALT_HTTP_ADDR="0.0.0.0:9991"
 ALT_P2P_ADDR="0.0.0.0:9992"
@@ -318,7 +319,7 @@ def test_nodes():
 
     # Test --export-node using standard filename.
     subprocess.run([DUNES_EXE, "--export-node", NODE_ALPHA, EXPORT_DIR], check=True)
-    assert os.path.exists(EXPORT_DIR + "/" + NODE_ALPHA + ".tgz")
+    assert os.path.exists( os.path.join(EXPORT_DIR,  NODE_ALPHA+".tgz")
 
     # Below check documents current behavior: node_bravo is active, however before exporting node_charlie was active.
     # Fix this in issue https://github.com/AntelopeIO/DUNES/issues/159
@@ -327,16 +328,16 @@ def test_nodes():
                         [NODE_CHARLIE, False, True, DEFAULT_HTTP_ADDR, DEFAULT_P2P_ADDR, DEFAULT_SHIP_ADDR]])
 
     # Test --export-node using provided filename.
-    subprocess.run([DUNES_EXE, "--export-node", NODE_BRAVO, EXPORT_DIR + "/bravo_export.tgz"], check=True)
-    assert os.path.exists(EXPORT_DIR + "/bravo_export.tgz")
+    subprocess.run([DUNES_EXE, "--export-node", NODE_BRAVO, os.path.join(EXPORT_DIR, "bravo_export.tgz")], check=True)
+    assert os.path.exists( os.path.join(EXPORT_DIR,"bravo_export.tgz") )
 
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, True, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_CHARLIE, False, True, DEFAULT_HTTP_ADDR, DEFAULT_P2P_ADDR, DEFAULT_SHIP_ADDR]])
 
     # Test --export-node using non-existing path.
-    subprocess.run([DUNES_EXE, "--export-node", NODE_CHARLIE, EXPORT_DIR + "/new_path/charlie_export.tgz"], check=True)
-    assert os.path.exists(EXPORT_DIR + "/new_path/charlie_export.tgz")
+    subprocess.run([DUNES_EXE, "--export-node", NODE_CHARLIE, os.path.join(EXPORT_DIR, *["new_path","charlie_export.tgz"])], check=True)
+    assert os.path.exists( os.path.join(EXPORT_DIR, *["new_path","charlie_export.tgz"]) )
 
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, False, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
@@ -347,14 +348,14 @@ def test_nodes():
 
     # Test --import-node
     #  Import each node from the export tests and
-    subprocess.run([DUNES_EXE, "--import-node", EXPORT_DIR + "/ALPHA_NODE.tgz", NODE_ALPHA], check=True)
+    subprocess.run([DUNES_EXE, "--import-node", os.path.join(EXPORT_DIR, "ALPHA_NODE.tgz"), NODE_ALPHA], check=True)
     validate_node_list([[NODE_ALPHA, True, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
 
-    subprocess.run([DUNES_EXE, "--import-node", EXPORT_DIR + "/bravo_export.tgz", NODE_BRAVO], check=True)
+    subprocess.run([DUNES_EXE, "--import-node", os.path.join(EXPORT_DIR, "bravo_export.tgz"), NODE_BRAVO], check=True)
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, True, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR]])
 
-    subprocess.run([DUNES_EXE, "--import-node", EXPORT_DIR + "/new_path/charlie_export.tgz", NODE_CHARLIE], check=True)
+    subprocess.run([DUNES_EXE, "--import-node", os.path.join(EXPORT_DIR, *["new_path","charlie_export.tgz"]), NODE_CHARLIE], check=True)
     validate_node_list([[NODE_ALPHA, False, False, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_BRAVO, False, True, ALT_HTTP_ADDR, ALT_P2P_ADDR, ALT_SHIP_ADDR],
                         [NODE_CHARLIE, True, True, DEFAULT_HTTP_ADDR, DEFAULT_P2P_ADDR, DEFAULT_SHIP_ADDR]])

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -44,8 +44,7 @@ def test_create_cmake_app():
     remove_existing()
 
     # Expected files.
-    filelist = [TEST_APP_DIR + '/',
-                os.path.join(TEST_APP_DIR, 'src'),
+    filelist = [os.path.join(TEST_APP_DIR, 'src'),
                 os.path.join(TEST_APP_DIR, *['src', PROJECT_NAME+'.cpp']),
                 os.path.join(TEST_APP_DIR, *['src', 'CMakeLists.txt']),
                 os.path.join(TEST_APP_DIR, 'include'),
@@ -67,7 +66,7 @@ def test_create_cmake_app():
     # Sort the lists and compare.
     filelist.sort()
     lst.sort()
-    assert filelist == lst
+    assert filelist == lst[1:]
 
     # Cleanup
     shutil.rmtree(TEST_APP_DIR)
@@ -80,10 +79,9 @@ def test_create_bare_app():
     remove_existing()
 
     # Expected file list.
-    filelist = [TEST_APP_DIR + '/',
-                os.path.join(TEST_APP_DIR, PROJECT_NAME+'.hpp'),
-                os.path.join(TEST_APP_DIR, PROJECT_NAME+'.cpp']),
-                os.path.join(TEST_APP_DIR, PROJECT_NAME+'.contracts.md']),
+    filelist = [os.path.join(TEST_APP_DIR, PROJECT_NAME+'.hpp'),
+                os.path.join(TEST_APP_DIR, PROJECT_NAME+'.cpp'),
+                os.path.join(TEST_APP_DIR, PROJECT_NAME+'.contracts.md'),
                 os.path.join(TEST_APP_DIR, 'README.txt')]
 
     subprocess.run([DUNES_EXE, "--create-bare-app", PROJECT_NAME, TEST_PATH], check=True)
@@ -95,7 +93,7 @@ def test_create_bare_app():
     # Sort and compare expected and actual.
     filelist.sort()
     lst.sort()
-    assert filelist == lst
+    assert filelist == lst[1:]
 
     # Cleanup
     shutil.rmtree(TEST_APP_DIR)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -21,9 +21,9 @@ from container import container
 
 
 PROJECT_NAME = "test_app"
-TEST_APP_DIR = TEST_PATH + "/" + PROJECT_NAME
-TEST_APP_BLD_DIR = TEST_APP_DIR + "/build/" + PROJECT_NAME
-TEST_APP_WASM = TEST_APP_BLD_DIR + "/" + PROJECT_NAME + ".wasm"    # TEST_APP_BLD_DIR + "/test_app.wasm"
+TEST_APP_DIR = os.path.join(TEST_PATH, PROJECT_NAME)
+TEST_APP_BLD_DIR = os.path.join(TEST_APP_DIR, *["build", PROJECT_NAME])
+TEST_APP_WASM = os.path.join(TEST_APP_BLD_DIR, PROJECT_NAME+".wasm")    # TEST_APP_BLD_DIR/test_app.wasm"
 
 
 def remove_existing():
@@ -45,16 +45,16 @@ def test_create_cmake_app():
 
     # Expected files.
     filelist = [TEST_APP_DIR + '/',
-                TEST_APP_DIR + '/src',
-                TEST_APP_DIR + '/src/' + PROJECT_NAME + '.cpp',
-                TEST_APP_DIR + '/src/CMakeLists.txt',
-                TEST_APP_DIR + '/include',
-                TEST_APP_DIR + '/include/' + PROJECT_NAME + '.hpp',
-                TEST_APP_DIR + '/ricardian',
-                TEST_APP_DIR + '/ricardian/' + PROJECT_NAME + '.contracts.md',
-                TEST_APP_DIR + '/build',
-                TEST_APP_DIR + '/CMakeLists.txt',
-                TEST_APP_DIR + '/README.txt']
+                os.path.join(TEST_APP_DIR, 'src'),
+                os.path.join(TEST_APP_DIR, *['src', PROJECT_NAME+'.cpp']),
+                os.path.join(TEST_APP_DIR, *['src', 'CMakeLists.txt']),
+                os.path.join(TEST_APP_DIR, 'include'),
+                os.path.join(TEST_APP_DIR, *['include', PROJECT_NAME+'.hpp']),
+                os.path.join(TEST_APP_DIR, 'ricardian'),
+                os.path.join(TEST_APP_DIR, *['ricardian', PROJECT_NAME+'.contracts.md']),
+                os.path.join(TEST_APP_DIR, 'build'),
+                os.path.join(TEST_APP_DIR, 'CMakeLists.txt'),
+                os.path.join(TEST_APP_DIR, 'README.txt')]
 
     # Create the test app.
     completed_process = subprocess.run([DUNES_EXE, "--create-cmake-app", PROJECT_NAME, TEST_PATH], check=True)
@@ -81,10 +81,10 @@ def test_create_bare_app():
 
     # Expected file list.
     filelist = [TEST_APP_DIR + '/',
-                TEST_APP_DIR + '/' + PROJECT_NAME + '.hpp',
-                TEST_APP_DIR + '/' + PROJECT_NAME + '.cpp',
-                TEST_APP_DIR + '/' + PROJECT_NAME + '.contracts.md',
-                TEST_APP_DIR + '/README.txt']
+                os.path.join(TEST_APP_DIR, PROJECT_NAME+'.hpp'),
+                os.path.join(TEST_APP_DIR, PROJECT_NAME+'.cpp']),
+                os.path.join(TEST_APP_DIR, PROJECT_NAME+'.contracts.md']),
+                os.path.join(TEST_APP_DIR, 'README.txt')]
 
     subprocess.run([DUNES_EXE, "--create-bare-app", PROJECT_NAME, TEST_PATH], check=True)
     assert os.path.isdir(TEST_APP_DIR) is True


### PR DESCRIPTION
Resolves #186 

The only failing tests are:
```
FAILED tests/a100_ensure_container_image_test.py::test_ensure_conatiner_image - AssertionError:
FAILED tests/z9999_bootstrap_cdt_version_test.py::test_version_bootstrapping - OSError: [WinError 193]
```
which will stop failing after https://github.com/AntelopeIO/DUNE/issues/202 is done.

Unfortunately it is not possible to add Windows to CI or run Windows tests (because of https://github.com/AntelopeIO/DUNE/issues/186#issuecomment-1576354044)